### PR TITLE
Add keycloak version build args

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,6 +86,8 @@ commands:
               --secret id=npm_token,env=NPM_TOKEN \
               --secret id=github_npm_token,env=GITHUB_NPM_TOKEN \
               --build-arg="commit_sha=${CIRCLE_SHA1}" \
+              --build-arg="KEYCLOAK_VERSION=25.0.4" \
+              --build-arg="KEYCLOAK_CLIENT_VERSION=25.0.1" \
               .
       - run:
           name: Push Docker image


### PR DESCRIPTION
We had forgotten to set the Keycloak version build arguments for the docker container. This does that