### PR TITLE
[BOURNE-1562] Cache client and role retrieval in role import step

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
@@ -34,6 +34,8 @@ import org.keycloak.representations.idm.authorization.PolicyRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceRepresentation;
 import org.keycloak.representations.idm.authorization.ResourceServerRepresentation;
 import org.keycloak.representations.idm.authorization.ScopeRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -47,13 +49,14 @@ import java.util.stream.Collectors;
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
 
-@Service
+@Service("clientRepository")
 @ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
 public class ClientRepository {
+    private static final Logger logger = LoggerFactory.getLogger(ClientRepository.class);
 
     private final RealmRepository realmRepository;
 
-    @Autowired
+    @Autowired(required = false)
     public ClientRepository(RealmRepository realmRepository) {
         this.realmRepository = realmRepository;
     }
@@ -87,6 +90,7 @@ public class ClientRepository {
     }
 
     public ClientRepresentation getByClientId(String realmName, String clientId) {
+        logger.debug("retrieving client: " + clientId);
         Optional<ClientRepresentation> foundClients = searchByClientId(realmName, clientId);
 
         if (foundClients.isEmpty()) {

--- a/src/main/java/de/adorsys/keycloak/config/repository/ClientRepositoryCacheWrapper.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ClientRepositoryCacheWrapper.java
@@ -1,0 +1,55 @@
+package de.adorsys.keycloak.config.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import de.adorsys.keycloak.config.util.DoubleIndexCache;
+
+@Service("clientRepositoryCacheWrapper")
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class ClientRepositoryCacheWrapper extends ClientRepository {
+    private static final Logger logger = LoggerFactory.getLogger(ClientRepositoryCacheWrapper.class);
+
+    private final Map<String, DoubleIndexCache<String, String, ClientRepresentation>> realmCaches = new HashMap<>();
+
+    @Autowired(required = false)
+    public ClientRepositoryCacheWrapper(RealmRepository realmRepository) {
+        super(realmRepository);
+    }
+
+    @Override
+    public ClientRepresentation getByClientId(String realm, String clientId) {
+        var client = getCache(realm).getBySecondary(clientId);
+        if (client != null) {
+            logger.debug(clientId + " found in cache");
+            return client;
+        }
+
+        client = super.getByClientId(realm, clientId);
+        getCache(realm).put(client.getId(), clientId, client);
+        return client;
+    }
+
+    @Override
+    public void remove(String realm, ClientRepresentation client) {
+        super.remove(realm, client);
+        getCache(realm).removeByPrimary(client.getId());
+    }
+
+    @Override
+    public void update(String realm, ClientRepresentation client) {
+        super.update(realm, client);
+        getCache(realm).removeByPrimary(client.getId());
+    }
+
+    private DoubleIndexCache<String, String, ClientRepresentation> getCache(String realm) {
+        return realmCaches.computeIfAbsent(realm, k -> new DoubleIndexCache<>());
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepository.java
@@ -21,6 +21,7 @@
 package de.adorsys.keycloak.config.repository;
 
 import de.adorsys.keycloak.config.exception.KeycloakRepositoryException;
+
 import org.keycloak.admin.client.resource.RoleResource;
 import org.keycloak.common.util.MultivaluedHashMap;
 import org.keycloak.representations.idm.ClientRepresentation;
@@ -36,11 +37,10 @@ import java.util.stream.Collectors;
 @Service
 @ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
 public class RoleCompositeRepository {
-
     private final RoleRepository roleRepository;
     private final ClientRepository clientRepository;
 
-    @Autowired
+    @Autowired(required = false)
     public RoleCompositeRepository(RoleRepository roleRepository, ClientRepository clientRepository) {
         this.roleRepository = roleRepository;
         this.clientRepository = clientRepository;

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepositoryCacheWrapper.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepositoryCacheWrapper.java
@@ -1,0 +1,18 @@
+package de.adorsys.keycloak.config.repository;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+@Service("roleCompositeRepositoryCacheWrapper")
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class RoleCompositeRepositoryCacheWrapper extends RoleCompositeRepository {
+
+    @Autowired(required = false)
+    public RoleCompositeRepositoryCacheWrapper(
+            @Qualifier("roleRepositoryCacheWrapper") RoleRepository roleRepository,
+            @Qualifier("clientRepositoryCacheWrapper") ClientRepository clientRepository) {
+        super(roleRepository, clientRepository);
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
@@ -26,6 +26,8 @@ import de.adorsys.keycloak.config.provider.KeycloakProvider;
 import de.adorsys.keycloak.config.resource.ManagementPermissions;
 import org.keycloak.admin.client.resource.*;
 import org.keycloak.representations.idm.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.lang.Nullable;
@@ -39,12 +41,14 @@ import jakarta.ws.rs.NotFoundException;
 @Service
 @ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
 public class RoleRepository {
+    private static final Logger logger = LoggerFactory.getLogger(RoleRepository.class);
+
     private final RealmRepository realmRepository;
     private final ClientRepository clientRepository;
     private final UserRepository userRepository;
     private final KeycloakProvider keycloakProvider;
 
-    @Autowired
+    @Autowired(required = false)
     public RoleRepository(
             RealmRepository realmRepository,
             ClientRepository clientRepository,
@@ -57,6 +61,7 @@ public class RoleRepository {
     }
 
     public Optional<RoleRepresentation> searchRealmRole(String realmName, String name) {
+        logger.debug("retrieving role: " + name);
         Optional<RoleRepresentation> maybeRole;
 
         RolesResource rolesResource = realmRepository.getResource(realmName).roles();

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleRepositoryCacheWrapper.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleRepositoryCacheWrapper.java
@@ -1,0 +1,66 @@
+package de.adorsys.keycloak.config.repository;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.keycloak.representations.idm.ClientRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+import de.adorsys.keycloak.config.provider.KeycloakProvider;
+import de.adorsys.keycloak.config.util.DoubleIndexCache;
+
+@Service("roleRepositoryCacheWrapper")
+@ConditionalOnProperty(prefix = "run", name = "operation", havingValue = "IMPORT", matchIfMissing = true)
+public class RoleRepositoryCacheWrapper extends RoleRepository {
+    private static final Logger logger = LoggerFactory.getLogger(RoleRepositoryCacheWrapper.class);
+
+    private final Map<String, DoubleIndexCache<String, String, RoleRepresentation>> realmCaches = new HashMap<>();
+
+    @Autowired(required = false)
+    public RoleRepositoryCacheWrapper(
+        RealmRepository realmRepository,
+        @Qualifier("clientRepositoryCacheWrapper") ClientRepository clientRepository,
+        UserRepository userRepository, KeycloakProvider keycloakProvider
+    ) {
+        super(realmRepository, clientRepository, userRepository, keycloakProvider);
+    }
+
+    @Override
+    public Optional<RoleRepresentation> searchRealmRole(String realm, String roleName) {
+        var cache = getCache(realm);
+        return Optional.ofNullable(cache.getBySecondary(roleName))
+            .map(role -> {
+                logger.debug(roleName + " found in cache");
+                return role;
+            })
+            .or(() -> super.searchRealmRole(realm, roleName)
+                .map(role -> {
+                    cache.put(role.getId(), roleName, role);
+                    return role;
+                })
+            );
+    }
+
+    @Override
+    public void deleteRealmRole(String realm, RoleRepresentation role) {
+        super.deleteRealmRole(realm, role);
+        getCache(realm).removeByPrimary(role.getId());
+    }
+
+    @Override
+    public void updateRealmRole(String realm, RoleRepresentation role) {
+        super.updateRealmRole(realm, role);
+        getCache(realm).removeByPrimary(role.getId());
+    }
+
+    private DoubleIndexCache<String, String, RoleRepresentation> getCache(String realm) {
+        return realmCaches.computeIfAbsent(realm, k -> new DoubleIndexCache<>());
+    }
+}

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
@@ -26,6 +26,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -42,8 +43,8 @@ public class ClientCompositeImport {
 
     @Autowired
     public ClientCompositeImport(
-            ClientRepository clientRepository,
-            RoleCompositeRepository roleCompositeRepository
+            @Qualifier("clientRepositoryCacheWrapper") ClientRepository clientRepository,
+            @Qualifier("roleCompositeRepositoryCacheWrapper") RoleCompositeRepository roleCompositeRepository
     ) {
         this.clientRepository = clientRepository;
         this.roleCompositeRepository = roleCompositeRepository;

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/RealmCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/RealmCompositeImport.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +41,9 @@ public class RealmCompositeImport {
     private final RoleCompositeRepository roleCompositeRepository;
 
     @Autowired
-    public RealmCompositeImport(RoleCompositeRepository roleCompositeRepository) {
+    public RealmCompositeImport(
+        @Qualifier("roleCompositeRepositoryCacheWrapper") RoleCompositeRepository roleCompositeRepository
+    ) {
         this.roleCompositeRepository = roleCompositeRepository;
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
@@ -25,6 +25,7 @@ import de.adorsys.keycloak.config.repository.RoleCompositeRepository;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -40,8 +41,8 @@ public class ClientCompositeImport {
     private final RoleCompositeRepository roleCompositeRepository;
 
     public ClientCompositeImport(
-            ClientRepository clientRepository,
-            RoleCompositeRepository roleCompositeRepository
+            @Qualifier("clientRepositoryCacheWrapper") ClientRepository clientRepository,
+            @Qualifier("roleCompositeRepositoryCacheWrapper") RoleCompositeRepository roleCompositeRepository
     ) {
         this.clientRepository = clientRepository;
         this.roleCompositeRepository = roleCompositeRepository;

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/RealmCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/RealmCompositeImport.java
@@ -25,6 +25,7 @@ import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 
@@ -40,7 +41,9 @@ public class RealmCompositeImport {
     private final RoleCompositeRepository roleCompositeRepository;
 
     @Autowired
-    public RealmCompositeImport(RoleCompositeRepository roleCompositeRepository) {
+    public RealmCompositeImport(
+        @Qualifier("roleCompositeRepositoryCacheWrapper") RoleCompositeRepository roleCompositeRepository
+    ) {
         this.roleCompositeRepository = roleCompositeRepository;
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/util/DoubleIndexCache.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/DoubleIndexCache.java
@@ -1,0 +1,47 @@
+package de.adorsys.keycloak.config.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.javers.common.collections.Pair;
+
+public class DoubleIndexCache<TPKey, TSKey, TVal> {
+    private final Map<TPKey, Pair<TSKey, TVal>> primaryCache = new HashMap<>();
+    private final Map<TSKey, Pair<TPKey, TVal>> secondaryCache = new HashMap<>();
+
+    public TVal getByPrimary(TPKey key) {
+        return primaryCache.getOrDefault(
+            key,
+            new Pair<TSKey, TVal>(null, null)
+        ).right();
+    }
+
+    public TVal getBySecondary(TSKey key) {
+        return secondaryCache.getOrDefault(
+            key,
+            new Pair<TPKey, TVal>(null, null)
+        ).right();
+    }
+
+    public void put(TPKey primaryKey, TSKey secondaryKey, TVal value) {
+        primaryCache.put(
+            primaryKey,
+            new Pair<TSKey,TVal>(secondaryKey, value)
+        );
+        secondaryCache.put(
+            secondaryKey,
+            new Pair<TPKey,TVal>(primaryKey, value)
+        );
+    }
+
+    public void removeByPrimary(TPKey key) {
+        Optional.ofNullable(primaryCache.remove(key))
+            .ifPresent(pair -> secondaryCache.remove(pair.left()));
+    }
+
+    public void removeBySecondary(TSKey key) {
+        Optional.ofNullable(secondaryCache.remove(key))
+            .ifPresent(pair -> primaryCache.remove(pair.left()));
+    }
+}


### PR DESCRIPTION
## Background

We noticed that the config job in CI was taking longer and longer as the number of clients increased. We also noticed that we were getting a lot of calls to the `GET /clients` route as the config job was running. The slowdown was happening during the role import step of config. There were long gaps in the logs after logging in `ClientCompositeImport`.

## Problem

I time-boxed this task, so I don't have a total grasp on the root cause, but here's what I found: when enumerating the client roles, multiple ones had essentially all of the clients (the vhost ones) as the role's client composites due to the way we are doing fine-grained authorization. [This nested for loop](https://github.com/adorsys/keycloak-config-cli/blob/f9e365561231c40596428dcdad96024704fe492c/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientRoleCompositeImportService.java#L58) is where the trouble starts.

The underlying structure of the code is paranoid: it checks and rechecks for representations from the API at each level of abstraction -- only querying keys (clientID, role name, etc.) are passed down. This means that even though multiple role composites contained the same clients, they were being retrieved one-by-one each iteration.

## Solution

Refactoring the underlying structure would have likely spiraled to a complete rewrite. Ideally, some of the services would be scoped to realms or clients where they could store representations and resources that don't change instead of all of them being functionally singletons.

The solution in this PR is simply to create a caching layer on top of the role and client repositories. This will prevent the repeated retrieval of all the clients by client ID and roles by name. Caching is only added to the client composite import step to prevent any potential bugs with cache invalidation (client composite import does not update the clients in any way that affects the ClientRepresentation, I think).

## Results

After testing on runs where the config is not changing, there was only a modest improvement [07:10.055](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252Ffcd62a569bca4821bd198384a1f8c470) vs [08:10.128](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252F9d42f889798b42dabf88afe9a3f097fe). This might become more pronounced for runs where the config is changing: where the expected runtime is around 30:00

## Other things to try

We disabled `IMPORT_CACHE_ENABLED` which should skip reconfiguration if the realm config hasn't changed. We can try enabling that.

We could go full refactor to prevent the unnecessary re-retrieval

Any other ideas?