### PR TITLE
[BOURNE-1562] Prevent querying all clients on searching matching client composites

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleCompositeRepository.java
@@ -81,7 +81,7 @@ public class RoleCompositeRepository {
     ) {
         return findClientComposites(
                 realmName,
-                () -> loadRealmRole(realmName, roleName)
+                loadRealmRole(realmName, roleName)
         ).entrySet()
                 .stream()
                 .collect(
@@ -114,7 +114,7 @@ public class RoleCompositeRepository {
     ) {
         return findClientComposites(
                 realmName,
-                () -> loadClientRole(realmName, roleClientId, roleName)
+                loadClientRole(realmName, roleClientId, roleName)
         ).entrySet()
                 .stream()
                 .collect(
@@ -349,19 +349,22 @@ public class RoleCompositeRepository {
 
     private MultivaluedHashMap<String, RoleRepresentation> findClientComposites(
             String realmName,
-            Supplier<RoleResource> roleSupplier
+            RoleResource roleResource
     ) {
         MultivaluedHashMap<String, RoleRepresentation> clientComposites = new MultivaluedHashMap<>();
 
-        List<ClientRepresentation> clients = clientRepository.getAll(realmName);
-
-        for (ClientRepresentation client : clients) {
-            Set<RoleRepresentation> clientRoleComposites = findClientComposites(
-                    realmName, client.getClientId(), roleSupplier
-            );
-
-            clientComposites.addAll(client.getClientId(), new ArrayList<>(clientRoleComposites));
-        }
+        roleResource
+            .getRoleComposites()
+            .stream()
+            .filter(composite -> composite.getClientRole())
+            .collect(Collectors.groupingBy(c -> c.getContainerId()))
+            .entrySet()
+            .forEach(kvp -> {
+                var client = clientRepository
+                    .getResourceById(realmName, kvp.getKey())
+                    .toRepresentation();
+                clientComposites.addAll(client.getClientId(), kvp.getValue());
+            });
 
         return clientComposites;
     }


### PR DESCRIPTION
Inverts the logic for finding client composites. Before this change, all clients were retrieved, then re-retrieved, then queried one-by-one whether this role has composites associated with the client.

This change retrieves the role composites, then queries clients based on the container ID. [Source](https://github.com/keycloak/keycloak/blob/ab33487eb861829395214506c14928ed13342a2e/services/src/main/java/org/keycloak/services/resources/admin/RoleResource.java#L142) on how it's done in Keycloak

This one seems to work. Got config time down to about [5 minutes](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252F4a06ccf2be0e4bc09cd45ca1758cdeee)
