### PR TITLE
BOURNE-1686: Use pagination or avoid fetching all clients/groups

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
+++ b/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
@@ -113,6 +113,7 @@ public class UsedAuthenticationFlowWorkaroundFactory {
 
             final Map<String, Map<String, String>> clientsWithFlow = new HashMap<>();
             // For all clients
+            logger.debug("Fetching all clients");
             for (ClientRepresentation client : clientRepository.getAll(realmImport.getRealm())) {
                 boolean updateClient = false;
                 final Map<String, String> authenticationFlowBindingOverrides = client.getAuthenticationFlowBindingOverrides();
@@ -135,6 +136,7 @@ public class UsedAuthenticationFlowWorkaroundFactory {
                     clientRepository.update(realmImport.getRealm(), client);
                 }
             }
+            logger.debug("Done fetching all clients");
 
             return clientsWithFlow;
         }

--- a/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
@@ -22,6 +22,7 @@ package de.adorsys.keycloak.config.repository;
 
 import de.adorsys.keycloak.config.exception.ImportProcessingException;
 import de.adorsys.keycloak.config.exception.KeycloakRepositoryException;
+import de.adorsys.keycloak.config.util.PaginationUtil;
 import de.adorsys.keycloak.config.util.ResponseUtil;
 import org.keycloak.admin.client.CreatedResponseUtil;
 import org.keycloak.admin.client.resource.ClientResource;
@@ -166,7 +167,10 @@ public class ClientRepository {
     }
 
     public final List<ClientRepresentation> getAll(String realmName) {
-        return getResource(realmName).findAll();
+        var clientsResource = getResource(realmName);
+        return PaginationUtil
+                .findAll((first, max) -> clientsResource.findAll(null, null, null, first, max))
+                .toList();
     }
 
     public void updateAuthorizationSettings(String realmName, String id, ResourceServerRepresentation authorizationSettings) {

--- a/src/main/java/de/adorsys/keycloak/config/repository/GroupRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/GroupRepository.java
@@ -21,6 +21,7 @@
 package de.adorsys.keycloak.config.repository;
 
 import de.adorsys.keycloak.config.exception.ImportProcessingException;
+import de.adorsys.keycloak.config.util.PaginationUtil;
 import org.keycloak.admin.client.CreatedResponseUtil;
 import org.keycloak.admin.client.resource.GroupResource;
 import org.keycloak.admin.client.resource.GroupsResource;
@@ -67,7 +68,7 @@ public class GroupRepository {
         GroupsResource groupsResource = realmRepository.getResource(realmName)
                 .groups();
 
-        return groupsResource.groups();
+        return PaginationUtil.findAll(groupsResource::groups).toList();
     }
 
     public List<GroupRepresentation> findGroupsByGroupPath(String realmName, List<String> groupPaths) {
@@ -91,7 +92,7 @@ public class GroupRepository {
         GroupsResource groupsResource = realmRepository.getResource(realmName)
                 .groups();
 
-        return groupsResource.groups()
+        return groupsResource.groups(groupName, true, null, null, true)
                 .stream()
                 .filter(g -> Objects.equals(g.getName(), groupName))
                 .findFirst();

--- a/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/RoleRepository.java
@@ -24,6 +24,7 @@ import de.adorsys.keycloak.config.exception.ImportProcessingException;
 import de.adorsys.keycloak.config.exception.KeycloakRepositoryException;
 import de.adorsys.keycloak.config.provider.KeycloakProvider;
 import de.adorsys.keycloak.config.resource.ManagementPermissions;
+import de.adorsys.keycloak.config.util.PaginationUtil;
 import org.keycloak.admin.client.resource.*;
 import org.keycloak.representations.idm.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -124,11 +125,12 @@ public class RoleRepository {
     }
 
     public Map<String, List<RoleRepresentation>> getClientRoles(String realmName) {
-        return realmRepository.getResource(realmName).clients().findAll().stream()
+        var clientsResource = realmRepository.getResource(realmName).clients();
+        return PaginationUtil
+                .findAll((first, max) -> clientsResource.findAll(null, null, null, first, max))
                 .collect(Collectors.toMap(
                         ClientRepresentation::getClientId,
-                        client -> realmRepository.getResource(realmName).clients()
-                                .get(client.getId()).roles().list()
+                        client -> clientsResource.get(client.getId()).roles().list()
                 ));
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -135,8 +135,10 @@ public class ClientImportService {
                     .stream()
                     .map(clientId -> clientRepository.getByClientId(realmImport.getRealm(), clientId));
         } else {
+            logger.debug("Fetching all clients");
             candidateClients = clientRepository.getAll(realmImport.getRealm())
                     .stream();
+            logger.debug("Done fetching all clients");
         }
 
         List<ClientRepresentation> clientsToRemove = candidateClients

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.ws.rs.WebApplicationException;
 
@@ -128,11 +129,19 @@ public class ClientImportService {
         boolean isState = importConfigProperties.getRemoteState().isEnabled();
         final List<String> stateClients = stateService.getClients();
 
-        List<ClientRepresentation> clientsToRemove = clientRepository.getAll(realmImport.getRealm())
-                .stream()
+        Stream<ClientRepresentation> candidateClients;
+        if (isState) {
+            candidateClients = stateClients
+                    .stream()
+                    .map(clientId -> clientRepository.getByClientId(realmImport.getRealm(), clientId));
+        } else {
+            candidateClients = clientRepository.getAll(realmImport.getRealm())
+                    .stream();
+        }
+
+        List<ClientRepresentation> clientsToRemove = candidateClients
                 .filter(client -> !KeycloakUtil.isDefaultClient(client)
                         && !importedClients.contains(client.getClientId())
-                        && (!isState || stateClients.contains(client.getClientId()))
                         && !(Objects.equals(realmImport.getRealm(), "master")
                         && client.getClientId().endsWith("-realm"))
                 )

--- a/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/GroupImportService.java
@@ -66,7 +66,9 @@ public class GroupImportService {
             return;
         }
 
+        logger.debug("Fetching all groups");
         List<GroupRepresentation> existingGroups = groupRepository.getAll(realmName);
+        logger.debug("Done fetching all groups");
 
         createOrUpdateGroups(groups, realmName);
 

--- a/src/main/java/de/adorsys/keycloak/config/service/RoleImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/RoleImportService.java
@@ -88,7 +88,9 @@ public class RoleImportService {
             existingRealmRoles = roleRepository.getRealmRoles(realmName);
         }
         if (clientRoleInImport) {
+            logger.debug("Fetching all clients");
             existingClientRoles = roleRepository.getClientRoles(realmName);
+            logger.debug("Done fetching all clients");
         }
 
         if (importConfigProperties.getManaged().getRole() == ImportConfigProperties.ImportManagedProperties.ImportManagedPropertiesValues.FULL) {

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
@@ -119,7 +119,9 @@ public class ClientCompositeImport {
             String realmRole,
             Map<String, List<String>> clientComposites
     ) {
+        logger.debug("Fetching all clients");
         Set<String> existingCompositeClients = clientRepository.getAllIds(realmName);
+        logger.debug("Done fetching all clients");
 
         Set<String> compositeClientsToRemove = existingCompositeClients.stream()
                 .filter(name -> !clientComposites.containsKey(name))

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
@@ -102,7 +102,9 @@ public class ClientCompositeImport {
     }
 
     private void removeRealmRoleClientComposites(String realmName, String realmRole, Map<String, List<String>> clientComposites) {
+        logger.debug("Fetching all clients");
         Set<String> existingCompositeClients = clientRepository.getAllIds(realmName);
+        logger.debug("Done fetching all clients");
 
         Set<String> compositeClientsToRemove = existingCompositeClients.stream()
                 .filter(name -> !clientComposites.containsKey(name))

--- a/src/main/java/de/adorsys/keycloak/config/util/PaginationUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/PaginationUtil.java
@@ -6,7 +6,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class PaginationUtil {
-    private static final int DEFAULT_PAGE_SIZE = 100;
+    private static final int DEFAULT_PAGE_SIZE = 20;
 
     public static <T> Stream<T> findAll(BiFunction<Integer, Integer, List<T>> getPage) {
         return findAll(DEFAULT_PAGE_SIZE, getPage);

--- a/src/main/java/de/adorsys/keycloak/config/util/PaginationUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/PaginationUtil.java
@@ -1,0 +1,21 @@
+package de.adorsys.keycloak.config.util;
+
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class PaginationUtil {
+    private static final int DEFAULT_PAGE_SIZE = 100;
+
+    public static <T> Stream<T> findAll(BiFunction<Integer, Integer, List<T>> getPage) {
+        return findAll(DEFAULT_PAGE_SIZE, getPage);
+    }
+
+    public static <T> Stream<T> findAll(int pageSize, BiFunction<Integer, Integer, List<T>> getPage) {
+        return IntStream.iterate(0, i -> i + 1)
+                .mapToObj(i -> getPage.apply(i * pageSize, pageSize))
+                .takeWhile(r -> !r.isEmpty())
+                .flatMap(List::stream);
+    }
+}


### PR DESCRIPTION
There are several places where the config tool tries to fetch all clients or groups in a single request, which will be cut off by the server if there is too much data. None of these should be _necessary_, but adding pagination fixes the error.

This PR does avoid fetching all clients in one scenario:

When "remote state" is enabled for clients (the default), Keycloak will only delete clients that were listed in the config tool's state. This prevents it from deleting clients that it didn't create.

When deciding what to delete, we can just fetch the clients that were already in the state, rather than listing all the clients in the realm. This should be a much smaller list, and prevents issues where the server cuts off the response when the list is too large.