### PR TITLE
[BOURNE-1717] Change getAll client methods to return streams

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
+++ b/src/main/java/de/adorsys/keycloak/config/factory/UsedAuthenticationFlowWorkaroundFactory.java
@@ -114,28 +114,29 @@ public class UsedAuthenticationFlowWorkaroundFactory {
             final Map<String, Map<String, String>> clientsWithFlow = new HashMap<>();
             // For all clients
             logger.debug("Fetching all clients");
-            for (ClientRepresentation client : clientRepository.getAll(realmImport.getRealm())) {
-                boolean updateClient = false;
-                final Map<String, String> authenticationFlowBindingOverrides = client.getAuthenticationFlowBindingOverrides();
-                // Search overrides with flowId
-                for (Map.Entry<String, String> flowBinding : authenticationFlowBindingOverrides.entrySet()) {
-                    if (flowId.equals(flowBinding.getValue())) {
-                        final Map<String, String> clientBinding = clientsWithFlow.computeIfAbsent(client.getClientId(), k -> new HashMap<>());
-                        // Save override and ...
-                        clientBinding.put(flowBinding.getKey(), flowBinding.getValue());
+            clientRepository.getAll(realmImport.getRealm())
+                    .forEach(client -> {
+                        boolean updateClient = false;
+                        final Map<String, String> authenticationFlowBindingOverrides = client.getAuthenticationFlowBindingOverrides();
+                        // Search overrides with flowId
+                        for (Map.Entry<String, String> flowBinding : authenticationFlowBindingOverrides.entrySet()) {
+                            if (flowId.equals(flowBinding.getValue())) {
+                                final Map<String, String> clientBinding = clientsWithFlow.computeIfAbsent(client.getClientId(), k -> new HashMap<>());
+                                // Save override and ...
+                                clientBinding.put(flowBinding.getKey(), flowBinding.getValue());
 
-                        // Search or create temporary auth flow
-                        final String temporaryClientFlow = createTemporaryClientFlow(patchedAuthenticationFlow);
+                                // Search or create temporary auth flow
+                                final String temporaryClientFlow = createTemporaryClientFlow(patchedAuthenticationFlow);
 
-                        authenticationFlowBindingOverrides.put(flowBinding.getKey(), temporaryClientFlow);
-                        updateClient = true;
-                    }
-                }
-                // Update client only if needed
-                if (updateClient) {
-                    clientRepository.update(realmImport.getRealm(), client);
-                }
-            }
+                                authenticationFlowBindingOverrides.put(flowBinding.getKey(), temporaryClientFlow);
+                                updateClient = true;
+                            }
+                        }
+                        // Update client only if needed
+                        if (updateClient) {
+                            clientRepository.update(realmImport.getRealm(), client);
+                        }
+                    });
             logger.debug("Done fetching all clients");
 
             return clientsWithFlow;

--- a/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
@@ -42,8 +42,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Response;
@@ -159,18 +158,15 @@ public class ClientRepository {
         return getResourceById(realmName, client.getId());
     }
 
-    public final Set<String> getAllIds(String realmName) {
+    public final Stream<String> getAllIds(String realmName) {
         return getAll(realmName)
-                .stream()
-                .map(ClientRepresentation::getClientId)
-                .collect(Collectors.toSet());
+                .map(ClientRepresentation::getClientId);
     }
 
-    public final List<ClientRepresentation> getAll(String realmName) {
+    public final Stream<ClientRepresentation> getAll(String realmName) {
         var clientsResource = getResource(realmName);
         return PaginationUtil
-                .findAll((first, max) -> clientsResource.findAll(null, null, null, first, max))
-                .toList();
+                .findAll((first, max) -> clientsResource.findAll(null, null, null, first, max));
     }
 
     public void updateAuthorizationSettings(String realmName, String id, ResourceServerRepresentation authorizationSettings) {

--- a/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/ClientImportService.java
@@ -136,23 +136,20 @@ public class ClientImportService {
                     .map(clientId -> clientRepository.getByClientId(realmImport.getRealm(), clientId));
         } else {
             logger.debug("Fetching all clients");
-            candidateClients = clientRepository.getAll(realmImport.getRealm())
-                    .stream();
-            logger.debug("Done fetching all clients");
+            candidateClients = clientRepository.getAll(realmImport.getRealm());
         }
 
-        List<ClientRepresentation> clientsToRemove = candidateClients
+        candidateClients
                 .filter(client -> !KeycloakUtil.isDefaultClient(client)
                         && !importedClients.contains(client.getClientId())
                         && !(Objects.equals(realmImport.getRealm(), "master")
                         && client.getClientId().endsWith("-realm"))
                 )
-                .toList();
-
-        for (ClientRepresentation clientToRemove : clientsToRemove) {
-            logger.debug("Remove client '{}' in realm '{}'", clientToRemove.getClientId(), realmImport.getRealm());
-            clientRepository.remove(realmImport.getRealm(), clientToRemove);
-        }
+                .forEach(clientToRemove -> {
+                    logger.debug("Remove client '{}' in realm '{}'", clientToRemove.getClientId(), realmImport.getRealm());
+                    clientRepository.remove(realmImport.getRealm(), clientToRemove);
+                });
+        logger.debug("Done deleting missing in import clients");
     }
 
     private void createOrUpdateClient(

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/client/ClientCompositeImport.java
@@ -120,12 +120,13 @@ public class ClientCompositeImport {
             Map<String, List<String>> clientComposites
     ) {
         logger.debug("Fetching all clients");
-        Set<String> existingCompositeClients = clientRepository.getAllIds(realmName);
-        logger.debug("Done fetching all clients");
 
-        Set<String> compositeClientsToRemove = existingCompositeClients.stream()
+        Set<String> compositeClientsToRemove = clientRepository
+                .getAllIds(realmName)
                 .filter(name -> !clientComposites.containsKey(name))
                 .collect(Collectors.toSet());
+
+        logger.debug("Done fetching all clients");
 
         Map<String, List<String>> clientCompositeRolesToBeRemoved = estimateClientCompositeRolesToBeRemoved(
                 realmName,

--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
@@ -103,12 +103,13 @@ public class ClientCompositeImport {
 
     private void removeRealmRoleClientComposites(String realmName, String realmRole, Map<String, List<String>> clientComposites) {
         logger.debug("Fetching all clients");
-        Set<String> existingCompositeClients = clientRepository.getAllIds(realmName);
-        logger.debug("Done fetching all clients");
 
-        Set<String> compositeClientsToRemove = existingCompositeClients.stream()
+        Set<String> compositeClientsToRemove = clientRepository
+                .getAllIds(realmName)
                 .filter(name -> !clientComposites.containsKey(name))
                 .collect(Collectors.toSet());
+
+        logger.debug("Done fetching all clients");
 
         Map<String, List<String>> clientCompositesToRemove = estimateRealmCompositeRolesToBeRemoved(
                 realmName,


### PR DESCRIPTION
We are getting an [OOM exception](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252F4ce49be9f46b41bb9a835f15aa6deb5a) when trying to run configuration on realms with a large number of clients.

This change prevents copying large streams to sets, then copying them to streams again and just returns the stream to be iterated over in the consumer

Tested on QA3. [No OOM thrown](https://app.circleci.com/pipelines/github/appfolio/keycloak-custom/4842/workflows/a2bc6464-7fde-4d1f-9e24-045a9e4696ba)