### PR TITLE
[BOURNE-1717] Prevent retrieving all clients in client composite import

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/rolecomposites/realm/ClientCompositeImport.java
@@ -20,7 +20,6 @@
 
 package de.adorsys.keycloak.config.service.rolecomposites.realm;
 
-import de.adorsys.keycloak.config.repository.ClientRepository;
 import de.adorsys.keycloak.config.repository.RoleCompositeRepository;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.slf4j.Logger;
@@ -36,14 +35,11 @@ import java.util.stream.Collectors;
 public class ClientCompositeImport {
     private static final Logger logger = LoggerFactory.getLogger(ClientCompositeImport.class);
 
-    private final ClientRepository clientRepository;
     private final RoleCompositeRepository roleCompositeRepository;
 
     public ClientCompositeImport(
-            ClientRepository clientRepository,
             RoleCompositeRepository roleCompositeRepository
     ) {
-        this.clientRepository = clientRepository;
         this.roleCompositeRepository = roleCompositeRepository;
     }
 
@@ -102,19 +98,10 @@ public class ClientCompositeImport {
     }
 
     private void removeRealmRoleClientComposites(String realmName, String realmRole, Map<String, List<String>> clientComposites) {
-        logger.debug("Fetching all clients");
-
-        Set<String> compositeClientsToRemove = clientRepository
-                .getAllIds(realmName)
-                .filter(name -> !clientComposites.containsKey(name))
-                .collect(Collectors.toSet());
-
-        logger.debug("Done fetching all clients");
-
         Map<String, List<String>> clientCompositesToRemove = estimateRealmCompositeRolesToBeRemoved(
                 realmName,
                 realmRole,
-                compositeClientsToRemove
+                clientComposites.keySet()
         );
 
         roleCompositeRepository.removeRealmRoleClientComposites(realmName, realmRole, clientCompositesToRemove);
@@ -137,18 +124,20 @@ public class ClientCompositeImport {
     private Map<String, List<String>> estimateRealmCompositeRolesToBeRemoved(
             String realmName,
             String roleName,
-            Set<String> compositeClientsToRemove
+            Collection<String> clientComposites
     ) {
-        Map<String, List<String>> clientRolesToRemove = new HashMap<>();
-        Map<String, List<String>> existingCompositesByClients = roleCompositeRepository.searchRealmRoleClientComposites(realmName, roleName);
+        var clientRolesToRemove = roleCompositeRepository
+                .searchRealmRoleClientComposites(
+                        realmName,
+                        roleName
+                );
 
-        for (String clientId : compositeClientsToRemove) {
-            if (existingCompositesByClients.containsKey(clientId)) {
-                List<String> existingCompositesByClient = existingCompositesByClients.get(clientId);
-
-                clientRolesToRemove.put(clientId, existingCompositesByClient);
-            }
-        }
+        clientComposites
+                .stream()
+                .filter(clientId -> clientRolesToRemove.containsKey(clientId))
+                .forEach(clientId -> {
+                    clientRolesToRemove.remove(clientId);
+                });
 
         return clientRolesToRemove;
     }


### PR DESCRIPTION
## Summary

This change updates the ClientCompositeImport services to more efficiently remove composites that need to be removed. The current method gets all clients and excludes config import client composites, then gets the intersection between that and the existing client composites. The proposed change simply retrieves the existing client composites and excludes the config client composites

### Current
![Screenshot 2025-04-21 at 7 56 23 AM](https://github.com/user-attachments/assets/2fdb7b7e-3ce3-496c-a73c-95768d6e1d58)

### Proposed
![Screenshot 2025-04-21 at 7 56 30 AM](https://github.com/user-attachments/assets/cf38b3e4-e197-47f2-8e5b-301931c7583d)
