### PR TITLE
[BOURNE-1703] Prevent recreating auth flows if priority values changed (but order remains the same)

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
+++ b/src/main/java/de/adorsys/keycloak/config/service/AuthenticationFlowsImportService.java
@@ -246,10 +246,16 @@ public class AuthenticationFlowsImportService {
             AuthenticationFlowRepresentation authenticationFlowToImport,
             AuthenticationFlowRepresentation existingAuthenticationFlow
     ) {
+        // Flows come in sorted by priority. Avoid comparing priority values so long
+        // as their order is the same.
         return !CloneUtil.deepEquals(
                 authenticationFlowToImport,
                 existingAuthenticationFlow,
-                "id"
+                "id", "authenticationExecutions"
+        ) || !CloneUtil.deepEquals(
+                authenticationFlowToImport.getAuthenticationExecutions(),
+                existingAuthenticationFlow.getAuthenticationExecutions(),
+                "priority"
         );
     }
 

--- a/src/main/java/de/adorsys/keycloak/config/util/CloneUtil.java
+++ b/src/main/java/de/adorsys/keycloak/config/util/CloneUtil.java
@@ -119,6 +119,12 @@ public class CloneUtil {
     }
 
     private static void removeIgnoredProperties(JsonNode jsonNode, String[] ignoredProperties) {
-        ((ObjectNode) jsonNode).remove(Arrays.asList(ignoredProperties));
+        if (jsonNode.isArray()) {
+            for (JsonNode node : jsonNode) {
+                removeIgnoredProperties(node, ignoredProperties);
+            }
+        } else {
+            ((ObjectNode) jsonNode).remove(Arrays.asList(ignoredProperties));
+        }
     }
 }

--- a/src/test/java/de/adorsys/keycloak/config/util/CloneUtilTest.java
+++ b/src/test/java/de/adorsys/keycloak/config/util/CloneUtilTest.java
@@ -31,6 +31,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.List;
+
 @ExtendWith(GithubActionsExtension.class)
 class CloneUtilTest {
     @Test
@@ -262,6 +264,52 @@ class CloneUtilTest {
         );
 
         assertTrue(CloneUtil.deepEquals(origin, other));
+    }
+
+    @Test
+    void shouldDeepEqualArraysWithIgnoredValue() {
+        var origin = List.of(
+                new TestObject(
+                        "my string",
+                        1234,
+                        123.123,
+                        1235L,
+                        null,
+                        null,
+                        new TestObject.InnerTestObject(
+                                "my other string",
+                                4321,
+                                52.72,
+                                null,
+                                null
+                        ),
+                        null
+                ),
+                new TestObject(
+                        "your string",
+                        4567,
+                        456.123,
+                        4567L,
+                        null,
+                        null,
+                        new TestObject.InnerTestObject(
+                                "my other string",
+                                7894,
+                                88.88,
+                                null,
+                                null
+                        ),
+                        null
+                )
+        );
+
+        var other = origin.stream()
+                .map(o -> CloneUtil.deepClone(o, "stringProperty"))
+                .toList();
+        other.get(0).setStringProperty("wrong string");
+        other.get(1).setStringProperty("wrong string again");
+
+        assertTrue(CloneUtil.deepEquals(origin, other, "stringProperty"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

We are seeing downtime when running the config job on production. This is happening because the config job detects (incorrectly) that there's been a change in the browser flow for foliospace and property realms. The config job will proceed to delete the browser flow and recreate it (we will follow-up to improve this so there's no downtime).

The incorrect determination that the flow has changed is due to the `priority` fields of the authentication steps being out of sync. Keycloak will auto-set the priority of the last step in a sub-flow to be 1 greater than the second to last step. This means if the JSON file has a priority 20 for the second-to-last step and 30 for the last step, then Keycloak will write priority 21 for the last step when that is committed. When we run the config again, the job will compare JSON with existing and see that the value of the priority of the last step is different, then delete and recreate the flow

This change alters the equality conditions to omit `priority` as a criterion for comparing flows. Flows should be passed into this method already sorted by priority