### PR TITLE
[BOURNE-1817] Retrieve realm-management client authz information in parts to prevent long-running query

### DIFF
--- a/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
+++ b/src/main/java/de/adorsys/keycloak/config/repository/ClientRepository.java
@@ -107,7 +107,7 @@ public class ClientRepository {
     }
 
     public ResourceServerRepresentation getAuthorizationConfigById(String realmName, String id) {
-        return getResourceById(realmName, id).authorization().exportSettings();
+        return getResourceById(realmName, id).authorization().getSettings();
     }
 
     public String getClientSecret(String realmName, String clientId) {
@@ -167,6 +167,24 @@ public class ClientRepository {
         var clientsResource = getResource(realmName);
         return PaginationUtil
                 .findAll((first, max) -> clientsResource.findAll(null, null, null, first, max));
+    }
+
+    public final Stream<ResourceRepresentation> getAuthorizationResources(String realmName, String clientId) {
+        var resourcesResource = getResourceById(realmName, clientId).authorization().resources();
+        return PaginationUtil
+                .findAll((first, max) -> resourcesResource.find(null, null, null, null, null, first, max));
+    }
+
+    public final List<ScopeRepresentation> getAuthorizationScopes(String realmName, String clientId) {
+        // paginated version not available in the resource. There is pagination in the 
+        // REST API at /clients/<id>/authz/resource-server/scope if we need it
+        return getResourceById(realmName, clientId).authorization().scopes().scopes();
+    }
+
+    public final Stream<PolicyRepresentation> getAuthorizationPolicies(String realmName, String clientId) {
+        var policyResource = getResourceById(realmName, clientId).authorization().policies();
+        return PaginationUtil
+                .findAll((first, max) -> policyResource.policies(null, null, null, null, null, null, null, null, first, max));
     }
 
     public void updateAuthorizationSettings(String realmName, String id, ResourceServerRepresentation authorizationSettings) {


### PR DESCRIPTION
## Summary

Separate out querying client authorization information to prevent long-running queries with permissions on every client. This gets the resources, scopes and permissions separately (resources and permissions are paginated queries). This should allow us to avoid getting [database timeouts](https://logs.appfolio.net/app/discover#/context/cecbe980-2685-11ee-abbc-710fd7b38729/FEHq65YBQzLantKzKpsC?_g=(filters:!())&_a=(columns:!(log),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!t,index:'5fc51450-d327-11ed-8466-df02490dd584',key:query,negate:!f,type:custom,value:'%7B%22wildcard%22:%7B%22ecs_task_definition%22:%7B%22value%22:%22keycloak*%22%7D%7D%7D'),query:(wildcard:(ecs_task_definition:(value:'keycloak*'))))))) for realms with a large number of clients.

This should un-block deploying keycloak-custom to production