### PR TITLE
[BOURNE-1844] Limit retrieving existing policies if NO_DELETE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ release.properties
 /*.json
 /test*
 /exports
+
+.factorypath


### PR DESCRIPTION
## Summary

Configuring the prod foliospace realm is taking about 2 hours. All the time is spent configuring the authorization for the `realm-client`. Retrieving the policies requires retrieving a ton of data that we don't use because we've set the job to `NO_CONFIG`.

This change checks the NO_CONFIG setting and only retrieves the policies associated with the ones in config, not all the ones in the realm.

Tested this on QA9. First, added ~20,000 clients. Next ran the foliospace token exchange migration for the new clients. Finally ran [master config](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252F422f00d8548c4cc380b8978fc6493032), then this [change config](https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logsV2:log-groups/log-group/$252Fecs$252Fkeycloak-config/log-events/ecs$252Fkeycloak-config$252Fbd59f3ef451544de8fa098c047b24796). This change dropped the config time from 39 minutes to 5 on this instance