### PR TITLE
[BOURNE-2206] Upgrade to Keycloak v26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,8 +88,8 @@ commands:
               --secret id=npm_token,env=NPM_TOKEN \
               --secret id=github_npm_token,env=GITHUB_NPM_TOKEN \
               --build-arg="commit_sha=${CIRCLE_SHA1}" \
-              --build-arg="KEYCLOAK_VERSION=25.0.4" \
-              --build-arg="KEYCLOAK_CLIENT_VERSION=25.0.1" \
+              --build-arg="KEYCLOAK_VERSION=26.1.0" \
+              --build-arg="KEYCLOAK_CLIENT_VERSION=26.0.4" \
               $DOCKER_HOST_BLOCK \
               .
       - run:


### PR DESCRIPTION
## Summary

This PR pulls in the upstream changes from the adorsys repository. The only change on top of that is building the keycloak-config-cli image to target Keycloak version 26