### PR TITLE
Restrict npm servers from docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,12 +82,15 @@ commands:
           name: Build Docker image
           working_directory: << parameters.app_folder >>
           command: |-
+            export DOCKER_HOST_BLOCK=$(curl -fsSL http://npm-yarn-blocklist.security.appf.io | tr ' ' '\n' | sed 's/^/--add-host=/' | sed 's/$/:127.0.0.1/' | tr '\n' ' ' | sed 's/ $//')
+            echo "Blocking hosts: $DOCKER_HOST_BLOCK"
             DOCKER_BUILDKIT=1 docker build -t "${FULL_IMAGE_TAG}" --progress=plain \
               --secret id=npm_token,env=NPM_TOKEN \
               --secret id=github_npm_token,env=GITHUB_NPM_TOKEN \
               --build-arg="commit_sha=${CIRCLE_SHA1}" \
               --build-arg="KEYCLOAK_VERSION=25.0.4" \
               --build-arg="KEYCLOAK_CLIENT_VERSION=25.0.1" \
+              $DOCKER_HOST_BLOCK \
               .
       - run:
           name: Push Docker image
@@ -125,4 +128,4 @@ workflows:
       - build-image:
           context:
             - appfolio_test_context
-            - appfolio_apps_ecr_image_build
+            - appfolio_apps_ecr_image_build_v2


### PR DESCRIPTION
## Summary

This change is to re-enable CCI workflows for this repo. Followed [these instructions](https://docs.google.com/document/d/1iuaT8wdNB-fm68rOE-aLtW6PHhLKe-S0WF-gXtTN32o/edit?tab=t.0) and updated CCI docker build to restrict pulling anything from npm. This should be irrelevant, because there's no javascript in this repo, but good to put up this guardrail

### Output from `docker_sbom_checker`

<img width="714" height="303" alt="Screenshot 2025-10-13 at 8 21 03 AM" src="https://github.com/user-attachments/assets/5c176825-9441-4083-b720-a576bd9f3f9d" />
