### PR TITLE
Add CODEOWNERS and catalog-info.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners for all files in this repo
+* @appfolio/platform-identity-authentication

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: keycloak-config-cli
+  description: "Fork of adorsys/keycloak-config-cli for importing YAML/JSON configuration files into Keycloak"
+spec:
+  type: tool
+  lifecycle: stable
+  owner: CODEOWNERS


### PR DESCRIPTION
Adds `.github/CODEOWNERS` and `catalog-info.yaml` to register this repo in the Developer Portal under `@appfolio/platform-identity-authentication` ownership.

Part of the repo ownership initiative: https://docs.google.com/spreadsheets/d/1sd6gorLtYuBb3W4JWK1R_K-PnSTmbTJoH27SQG1_8gU